### PR TITLE
Updating image to work with OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,15 @@ RUN chown -R 1001:0 /srv/shiny-server && \
     chmod -R ug+rwx /srv/shiny-server && \
     mkdir -p /var/log/shiny-server && \
     chown -R 1001:0 /var/log/shiny-server && \
+    chmod -R ug+rwx /var/log/shiny-server && \
+    mkdir -p /var/lib/shiny-server/bookmarks && \
+    chown -R 1001:0 /var/lib/shiny-server/bookmarks && \
+    chmod -R ug+rwx /var/lib/shiny-server/bookmarks && \
     touch /tmp/passwd && \
     chmod 664 /tmp/passwd
 
 # Set associated nss_wrapper environment variables.
-ENV LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+ENV LD_PRELOAD=/usr/lib/libnss_wrapper.so
 ENV NSS_WRAPPER_PASSWD=/tmp/passwd
 ENV NSS_WRAPPER_GROUP=/etc/group
 

--- a/passwd.template
+++ b/passwd.template
@@ -1,0 +1,14 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+default:x:${USER_ID}:${GROUP_ID}:Shiny User:${HOME}:/sbin/nologin

--- a/shiny-server.conf
+++ b/shiny-server.conf
@@ -1,10 +1,10 @@
 # Define the user we should use when spawning R Shiny processes
-run_as shiny;
+run_as default;
 
 # Define a top-level server which will listen on a port
 server {
   # Instruct this server to listen on port 80. The app at dokku-alt need expose PORT 80, or 500 e etc. See the docs
-  listen 80;
+  listen 8080;
 
   # Define the location available at the base URL
   location / {
@@ -12,11 +12,11 @@ server {
     # Run this location in 'site_dir' mode, which hosts the entire directory
     # tree at '/srv/shiny-server'
     site_dir /srv/shiny-server;
-    
+
     # Define where we should put the log files for this location
     log_dir /var/log/shiny-server;
-    
-    # Should we list the contents of a (non-Shiny-App) directory when the user 
+
+    # Should we list the contents of a (non-Shiny-App) directory when the user
     # visits the corresponding URL?
     directory_index on;
   }

--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -1,7 +1,10 @@
-#!/bin/sh
-
-# Make sure the directory for individual app logs exists
-mkdir -p /var/log/shiny-server
-chown shiny.shiny /var/log/shiny-server
-
-exec shiny-server >> /var/log/shiny-server.log 2>&1
+#!/bin/bash
+## Set up an alternate passwd file using libnss_wrapper since the Shiny server
+## requires a named user to work and OpenShift docker images get a random uid
+## with no username attached to it. The envsubst command from gettext package
+## is used to replace environment variables in the template.
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < /tmp/passwd.template > /tmp/passwd
+## Run the existing shiny script, output is captured to stdout
+exec shiny-server


### PR DESCRIPTION
The changes that were implemented involved using nss_wrapper to give the unique UID an entry in /etc/passwd. In addition, we updated the Dockerfile to bind to 8080, created the necessary directory structure (with proper permissions), and modified the start CMD. This now allows the image to function successfully on OpenShift.